### PR TITLE
Fix ABSL_BUILD_DLL mode (absl_make_dll) with mingw

### DIFF
--- a/CMake/AbseilDll.cmake
+++ b/CMake/AbseilDll.cmake
@@ -829,6 +829,9 @@ function(absl_make_dll)
       ${_dll_libs}
       ${ABSL_DEFAULT_LINKOPTS}
       $<$<BOOL:${ANDROID}>:-llog>
+      $<$<BOOL:${MINGW}>:-ladvapi32>
+      $<$<BOOL:${MINGW}>:-ldbghelp>
+      $<$<BOOL:${MINGW}>:-lbcrypt>
   )
   set_target_properties(${_dll} PROPERTIES
     LINKER_LANGUAGE "CXX"


### PR DESCRIPTION
Fixes linking errors when compiling `ABSL_BUILD_MONOLITHIC_SHARED_LIBS=ON` with mingw, by adding the missing `-ladvapi32`, `-ldbghelp`, and `-lbcrypt` in `absl_make_dll()`.
